### PR TITLE
Rescoped default to within a model

### DIFF
--- a/aws_important_notes.yml
+++ b/aws_important_notes.yml
@@ -131,6 +131,7 @@ rules:
   aws-default:
     description: 'default is not supported by API Gateway'
     severity: error
-    given: $..default
+    given: $.components.schemas.*.properties.*
     then:
+      field: default
       function: undefined


### PR DESCRIPTION
Fixes the false-positive identification of the default property outside $.components.schemas

Closes #1 