### PR TITLE
Removed additional properties and upgraded ajv draft-04 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## Unreleased
+## [1.0.2] - 2021-06-04
+
+- downgraded additionalProperties to a hint, as is supported by API Gateway.
+- Upgraded to ajv 8.5.0 to take advantage of the new ajv-draft-04 library
+- Added ajv-formats to allow the subset of formats available in draft-04, as published https://datatracker.ietf.org/doc/html/draft-fge-json-schema-validation-00#section-7.2
 ## [1.0.1] - 2021-05-10
 
 - added draft-4 schema checking rule & function

--- a/aws_important_notes.yml
+++ b/aws_important_notes.yml
@@ -65,7 +65,7 @@ rules:
       function: undefined
   
   aws-model-field-additionalProperties:
-    description: 'The additionalProperties field is supported in Models.'
+    description: 'The additionalProperties field is supported in Models.  However, if you remove it, it will remain set to the last value specified.'
     severity: hint
     given: $.components.schemas.*
     then:

--- a/aws_important_notes.yml
+++ b/aws_important_notes.yml
@@ -65,12 +65,12 @@ rules:
       function: undefined
   
   aws-model-field-additionalProperties:
-    description: 'The additionalProperties field is not supported in Models.'
-    severity: error
+    description: 'The additionalProperties field is supported in Models.'
+    severity: hint
     given: $.components.schemas.*
     then:
       field: additionalProperties
-      function: undefined
+      function: defined
 
   aws-model-fields-anyOf:
     description: 'The anyOf field is not supported in Models.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "ajv": "^6.12.3"
+        "ajv": "^8.5.0",
+        "ajv-draft-04": "^1.0.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.14.1",
@@ -2097,18 +2098,31 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+      "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv-keywords": {
@@ -3576,7 +3590,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3838,6 +3853,28 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -4985,9 +5022,9 @@
       "dev": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -6117,6 +6154,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -6540,6 +6585,28 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -7981,9 +8048,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -9836,15 +9903,21 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+      "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
+    },
+    "ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
@@ -10993,7 +11066,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -11192,6 +11266,26 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "has": {
@@ -12088,9 +12182,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -12972,6 +13066,11 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -13304,6 +13403,26 @@
         "@types/json-schema": "^7.0.6",
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "semver": {
@@ -14435,9 +14554,9 @@
       }
     },
     "ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.5.0",
-        "ajv-draft-04": "^1.0.0"
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^2.1.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.14.1",
@@ -2118,6 +2119,22 @@
       "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
       "peerDependencies": {
         "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
+      "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
       },
       "peerDependenciesMeta": {
         "ajv": {
@@ -9917,6 +9934,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
       "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "requires": {}
+    },
+    "ajv-formats": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
+      "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
       "requires": {}
     },
     "ajv-keywords": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "author": "Andy Loughran",
   "license": "Apache-2.0",
   "dependencies": {
-    "ajv": "^6.12.3"
+    "ajv": "^8.5.0",
+    "ajv-draft-04": "^1.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.14.1",
@@ -34,12 +35,19 @@
   "jest": {
     "verbose": true,
     "collectCoverage": true,
-    "moduleFileExtensions": ["js", "json", "mjs", "jsx", "ts", "tsx", "node"],
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "mjs",
+      "jsx",
+      "ts",
+      "tsx",
+      "node"
+    ],
     "transform": {
       "^.+\\.js$": "babel-jest",
       "^.+\\.mjs$": "babel-jest"
     },
-   
     "testRegex": "((\\.|/*.)(spec))\\.js?$"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "ajv": "^8.5.0",
-    "ajv-draft-04": "^1.0.0"
+    "ajv-draft-04": "^1.0.0",
+    "ajv-formats": "^2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.14.1",

--- a/src/__tests__/draft4.spec.js
+++ b/src/__tests__/draft4.spec.js
@@ -1,5 +1,6 @@
 import draft4 from "../draft4";
-
+// https://datatracker.ietf.org/doc/html/draft-fge-json-schema-validation-00#section-4.1
+// Including additional formats as described above ^^
 describe("JSONSchema Draft-4", () => {
   test("A valid JSON Schema should pass with no errors", () => {
     const input = {
@@ -57,6 +58,20 @@ describe("JSONSchema Draft-4", () => {
       }
     }
     const output = [{"message": "Not valid JSONSchema4: Error: unknown format \"date\" ignored in schema at path \"#/properties/isadate\""}];
+    expect(draft4(input)).toEqual(output);
+  });
+
+  test("format date-time is valid in draft-4", () => {
+    const input = {
+      "type": "object",
+      "properties": {
+        "isadate": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+    const output = undefined;
     expect(draft4(input)).toEqual(output);
   });
 });

--- a/src/__tests__/draft4.spec.js
+++ b/src/__tests__/draft4.spec.js
@@ -40,9 +40,23 @@ describe("JSONSchema Draft-4", () => {
     }
     const output = [
       {
-        message: 'Not valid JSONSchema4: Error: unknown format "string" is used in schema at path "#/properties/name"'
+        message: 'Not valid JSONSchema4: Error: unknown format "string" ignored in schema at path "#/properties/name"'
       }
     ];
+    expect(draft4(input)).toEqual(output);
+  });
+
+  test("format date isn't valid in draft-4", () => {
+    const input = {
+      "type": "object",
+      "properties": {
+        "isadate": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    }
+    const output = [{"message": "Not valid JSONSchema4: Error: unknown format \"date\" ignored in schema at path \"#/properties/isadate\""}];
     expect(draft4(input)).toEqual(output);
   });
 });

--- a/src/draft4.mjs
+++ b/src/draft4.mjs
@@ -1,14 +1,7 @@
-import ajv, { ErrorObject } from 'ajv';
-import * as draft4MetaSchema from "ajv/lib/refs/json-schema-draft-04.json"
+import Ajv from "ajv-draft-04"
 
 
-const ajvValidator = ajv({
-    schemaId: "auto",
-    strict: true,
-    strictKeywords: true,
-    strictDefaults: true
-    });
-ajvValidator.addMetaSchema(draft4MetaSchema)
+const ajvValidator = new Ajv();
 ajvValidator.addKeyword("example"); // Added 'example' keyword as picked up by `aws-example-tag` rule.
 
 // function validate_json() {

--- a/src/draft4.mjs
+++ b/src/draft4.mjs
@@ -1,8 +1,10 @@
 import Ajv from "ajv-draft-04"
+import addFormats from "ajv-formats"
 
-
-const ajvValidator = new Ajv();
-ajvValidator.addKeyword("example"); // Added 'example' keyword as picked up by `aws-example-tag` rule.
+const ajv = new Ajv();
+addFormats(ajv, ["date-time","email","hostname","ipv4","ipv6","uri"])
+    
+ajv.addKeyword("example"); // Added 'example' keyword as picked up by `aws-example-tag` rule.
 
 // function validate_json() {
     
@@ -10,7 +12,7 @@ ajvValidator.addKeyword("example"); // Added 'example' keyword as picked up by `
 
 module.exports = targetVal => {
     try {
-        ajvValidator.compile(targetVal);
+        ajv.compile(targetVal);
     }
     catch (error) {
         return [ 


### PR DESCRIPTION
- additionalProperties is supported by AWS API Gateway; so downgrading to a hint if defined.
- AJV has a new mechanism for validation of draft-04 schemas, so have updated the draft4 function to use this new method.

