### PR TITLE
/ should be a valid path

### DIFF
--- a/aws_important_notes.yml
+++ b/aws_important_notes.yml
@@ -20,7 +20,7 @@ rules:
       field: "@key"
       function: pattern
       functionOptions:
-        match: "^\/[A-Za-z0-9.,{}\/]+"
+        match: "^\/[A-Za-z0-9.,{}\/]*"
   
   aws-model-names:
     description: 'Model names can only contain alphanumeric characters.'


### PR DESCRIPTION
The original implementation forbade / as path, which is not ideal - adjusting it to allow the case.